### PR TITLE
explicit cast of $val to string for ctype_digit and array access

### DIFF
--- a/lib/sheet.php
+++ b/lib/sheet.php
@@ -81,7 +81,7 @@ class Sheet extends \Prefab {
 				elseif (is_string($val))
 					$val = trim($val);
 				$xls.= (is_int($val)
-					|| (ctype_digit($val) && ($val[0]!='0' && strlen($val)>1)))
+					|| (ctype_digit(strval($val)) && (strval($val)[0]!='0' && strlen($val)>1)))
 					? $this->xlsWriteNumber($i,$c,$val)
 					: $this->xlsWriteString($i,$c,utf8_decode($val));
 				next($headers);


### PR DESCRIPTION
fixes #5 
Here's a quick fix that allows for data containing types other than `String`, as long as they can be cast to a string (as used to be the case). It correctly uses `xlsWriteNumber` for strings that only contain numbers, as long as they don't have a leading 0.